### PR TITLE
Github Actions: add Skynode cross-compilation job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -556,3 +556,72 @@ jobs:
         run: docker pull auterion/mavsdk-ubuntu-20.04-apx4-sitl-${{ matrix.px4_version }}
       - name: Run image in container and Test
         run: docker run -v $(pwd):/home/user/MAVSDK --env=PX4_VERSION="auterion-${{ matrix.px4_version }}" auterion/mavsdk-ubuntu-20.04-apx4-sitl-${{ matrix.px4_version }} /home/user/MAVSDK/tools/run-sitl-tests.sh /home/user/Firmware
+
+  distro-multi-buildenv:
+    name: Build/deb packaging for Skynode and other archs
+    env:
+      DOCKER_BUILDKIT: 1
+      PKG_VERSION: 1
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        config:
+          - {architecture: "amd64" }
+          - {architecture: "arm64" }
+          - {architecture: "armhf" }
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Docker Login
+        uses: Azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Prepare environment
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        if: matrix.config.architecture != 'amd64'
+      - name: Pull multibuild-env
+        run:  docker pull auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0
+      - name: Build and package MAVSDK (Pull Request)
+        if: startsWith(github.ref, 'refs/pull/')
+        run: |
+          git fetch --all --tags
+          echo "TAG_VERSION=$(git describe --always --tags $(git rev-list --tags --max-count=1) | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
+          docker run -t \
+            -v $(pwd):/buildroot \
+            --workdir "/buildroot" \
+            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
+            /bin/bash -c "./tools/generate_debian_changelog.sh ${{ env.PKG_VERSION }} ${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+      - name: Upload libmavsdk0_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv artefact
+        uses: actions/upload-artifact@v2
+        if: startsWith(github.ref, 'refs/pull/')
+        with:
+          name: libmavsdk0_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv_${{ matrix.config.architecture }}.deb
+          path: output/skynode/libmavsdk0_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv_${{ matrix.config.architecture }}.deb
+          retention-days: 2
+      - name: Upload libmavsdk-dev_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv artefact
+        uses: actions/upload-artifact@v2
+        if: startsWith(github.ref, 'refs/pull/')
+        with:
+          name: libmavsdk-dev_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv_${{ matrix.config.architecture }}.deb
+          path: output/skynode/libmavsdk-dev_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv_${{ matrix.config.architecture }}.deb
+          retention-days: 2
+      - name: Build and package MAVSDK (Release)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "TAG_VERSION=$(${GITHUB_REF} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
+          docker run -t \
+            -v $(pwd):/buildroot \
+            --workdir "/buildroot" \
+            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
+            /bin/bash -c "./tools/generate_debian_changelog.sh ${{ env.PKG_VERSION }} ${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+      - name: Publish artefacts
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file_glob: true
+          file: output/skynode/*.deb
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img alt="MAVSDK" src="https://mavsdk.mavlink.io/develop/assets/site/sdk_logo_full.png" width="400">
 
-[![GitHub Actions Status](https://github.com/mavlink/MAVSDK/workflows/Build%20and%20Test/badge.svg?branch=develop)](https://github.com/mavlink/MAVSDK/actions?query=branch%3Adevelop)
-[![Coverage Status](https://coveralls.io/repos/github/mavlink/MAVSDK/badge.svg?branch=develop)](https://coveralls.io/github/mavlink/MAVSDK?branch=develop)
+[![GitHub Actions Status](https://github.com/Auterion/MAVSDK/workflows/Build%20and%20Test/badge.svg?branch=develop)](https://github.com/Auterion/MAVSDK/actions?query=branch%3Adevelop)
+[![Upstream Coverage Status](https://coveralls.io/repos/github/mavlink/MAVSDK/badge.svg?branch=develop)](https://coveralls.io/github/mavlink/MAVSDK?branch=develop)
 
 ## Description
 

--- a/tools/generate_debian_changelog.sh
+++ b/tools/generate_debian_changelog.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 
 # We want to extract "1.2.3" from "v1.2.3-5-g123abc".
-tag_version=`git describe --always --tags | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'`
+default_tag_version=`git describe --always --tags $(git rev-list --tags --max-count=1) | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'`
 
 # Default to 1 for package version
-if [ "$#" == 1 ]; then
-    package_version=$1
+if [ -z "$1" ]; then
+    package_version=1
 else
-    package_version="1"
+    package_version=$1
+fi
+
+if [ -z "$2" ]; then
+    tag_version=$default_tag_version
+else
+    tag_version=$2
 fi
 
 # Date according to RFC 5322


### PR DESCRIPTION
Shifting validation and testing "to the left".

Context: I added a build/packaging step that uses the `muit-buildenv` container used in `auterion_distro_resin` repo to build and package stuff to the Skynode and other archs. The purpose of this is that we shift the testing/validation "to the left" (if you consider and CD pipeline from left to right), where the first step of validation of the code to be deployed to our supported HW is done on the application/service/library source immediately, not on at the last level, though also guaranteeing it passes using the same tooling that is used on the distro packaging and serving.