### PR TITLE
Add APX4-SITL-v2.2 Dockerfile and tests against APX4 2.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -546,7 +546,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        px4_version: [v2.1, develop]
+        px4_version: [v2.2, v2.1, develop]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/docker/Dockerfile-Ubuntu-20.04-APX4-SITL-v2.1
+++ b/docker/Dockerfile-Ubuntu-20.04-APX4-SITL-v2.1
@@ -4,7 +4,7 @@
 #
 FROM mavsdk/mavsdk-ubuntu-20.04 as intermediate
 LABEL stage=intermediate
-MAINTAINER Julian Oes <julian@oes.ch>
+MAINTAINER Nuno Marques <nuno@auterion.com>
 
 WORKDIR /home/user/MAVSDK
 ENV FIRMWARE_DIR /home/user/Firmware

--- a/docker/Dockerfile-Ubuntu-20.04-APX4-SITL-v2.2
+++ b/docker/Dockerfile-Ubuntu-20.04-APX4-SITL-v2.2
@@ -1,5 +1,5 @@
 #
-# Auterion PX4 develop SITL testing environment for MAVSDK based on Ubuntu 20.04.
+# Auterion PX4 v2.2 SITL testing environment for MAVSDK based on Ubuntu 20.04.
 # Author: Julian Oes <julian@oes.ch>
 #
 FROM mavsdk/mavsdk-ubuntu-20.04 as intermediate
@@ -27,7 +27,7 @@ RUN mkdir -p $/root/.ssh/ && \
     ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
 RUN git clone git@github.com:Auterion/PX4_firmware_private.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} checkout develop
+RUN git -C ${FIRMWARE_DIR} checkout v1.11.0-2.2.0
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 
 FROM mavsdk/mavsdk-ubuntu-20.04

--- a/docker/build_and_push_auterion_docker_images.sh
+++ b/docker/build_and_push_auterion_docker_images.sh
@@ -3,8 +3,10 @@
 
 set -e
 
+docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" -f Dockerfile-Ubuntu-20.04-APX4-SITL-v2.2 -t auterion/mavsdk-ubuntu-20.04-apx4-sitl-v2.2 .
 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" -f Dockerfile-Ubuntu-20.04-APX4-SITL-v2.1 -t auterion/mavsdk-ubuntu-20.04-apx4-sitl-v2.1 .
 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" -f Dockerfile-Ubuntu-20.04-APX4-SITL-develop -t auterion/mavsdk-ubuntu-20.04-apx4-sitl-develop .
 
+docker push auterion/mavsdk-ubuntu-20.04-apx4-sitl-v2.2:latest
 docker push auterion/mavsdk-ubuntu-20.04-apx4-sitl-v2.1:latest
 docker push auterion/mavsdk-ubuntu-20.04-apx4-sitl-develop:latest


### PR DESCRIPTION
We should at least keep the last 2 releases supported + develop, As soon as 2.3 is released, we remove 2.1, and so on.

Note that for the custom actions I still need to fix the tests, as I need to use the time factor as well inside the python scripts.