### PR TITLE
#DIS-1158 adding ftp_server comp id MAV_COMP_ID_ONBOARD_COMPUTER4=194

### DIFF
--- a/examples/ftp_server/ftp_server.cpp
+++ b/examples/ftp_server/ftp_server.cpp
@@ -19,6 +19,10 @@
 #define ERROR_CONSOLE_TEXT "\033[31m" // Turn text on console red
 #define NORMAL_CONSOLE_TEXT "\033[0m" // Restore normal console colour
 
+#define DEFAULT_SYSTEM_ID 1
+#define MAV_COMP_ID_ONBOARD_COMPUTER4 194
+#define FTP_SERVER_DESCRIPTION "ftp server"
+
 using namespace mavsdk;
 
 void usage(const std::string& bin_name)
@@ -38,7 +42,8 @@ int main(int argc, char** argv)
     }
 
     Mavsdk mavsdk;
-    Mavsdk::Configuration configuration(Mavsdk::Configuration::UsageType::CompanionComputer);
+    Mavsdk::Configuration configuration(DEFAULT_SYSTEM_ID, MAV_COMP_ID_ONBOARD_COMPUTER4, true);
+    configuration.set_component_description(FTP_SERVER_DESCRIPTION);
     mavsdk.set_configuration(configuration);
     ConnectionResult connection_result = mavsdk.setup_udp_remote(argv[1], std::stoi(argv[2]));
     if (connection_result != ConnectionResult::Success) {


### PR DESCRIPTION
needs to assign new comp ids and description to ftp_server to differentiate it from other onboard computers components on flight and on debug 
we are hardcoding this number as including mavlink directly to provide access to MAV_COMPONENT enum would be overkill