### PR TITLE
mavlink-ftp: Do not continue with sending data on receiving an old ack

### DIFF
--- a/src/plugins/ftp/ftp_impl.cpp
+++ b/src/plugins/ftp/ftp_impl.cpp
@@ -54,6 +54,11 @@ void FtpImpl::_process_ack(PayloadHeader* payload)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
 
+    if (payload->seq_number < _seq_number) {
+        // received an ack for a previous seq that we already considered done
+        return;
+    }
+
     if (_curr_op != payload->req_opcode) {
         LogWarn() << "Received ACK not matching our current operation";
         return;

--- a/src/plugins/ftp/ftp_impl.cpp
+++ b/src/plugins/ftp/ftp_impl.cpp
@@ -54,7 +54,8 @@ void FtpImpl::_process_ack(PayloadHeader* payload)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
 
-    if (payload->seq_number < _seq_number) {
+    if ((uint16_t)((_seq_number - 1) - payload->seq_number) < (std::numeric_limits<uint16_t>::max()/2)) {
+        // (payload->seq_number < _seq_number) with wrap around
         // received an ack for a previous seq that we already considered done
         return;
     }

--- a/src/plugins/ftp/ftp_impl.cpp
+++ b/src/plugins/ftp/ftp_impl.cpp
@@ -21,6 +21,13 @@ namespace mavsdk {
 
 using namespace std::placeholders; // for `_1`
 
+bool seq_lt(uint16_t a, uint16_t b)
+{
+    // From https://en.wikipedia.org/wiki/Serial_number_arithmetic
+    return (a < b && (b - a) < (std::numeric_limits<uint16_t>::max() / 2)) ||
+           (a > b && (a - b) > (std::numeric_limits<uint16_t>::max() / 2));
+}
+
 FtpImpl::FtpImpl(System& system) : PluginImplBase(system)
 {
     _parent->register_plugin(this);
@@ -54,7 +61,7 @@ void FtpImpl::_process_ack(PayloadHeader* payload)
 {
     std::lock_guard<std::mutex> lock(_curr_op_mutex);
 
-    if ((uint16_t)((_seq_number - 1) - payload->seq_number) < (std::numeric_limits<uint16_t>::max()/2)) {
+    if (seq_lt(payload->seq_number, _seq_number)) {
         // (payload->seq_number < _seq_number) with wrap around
         // received an ack for a previous seq that we already considered done
         return;


### PR DESCRIPTION
This fixes a bug that could cause sender and receiver to get out of sync.
When the ack from receiver is delayed, the sender re-transmits the package. When the ack then arrives anyways, the sender continues with the next package. Since we already re-sent the previous package, another ack for the previous package is received. This makes the sender again move to the next package. From here on, the receiver and sender are out of sync.

This is generally not an issue, but when now an ack gets lost, the sender no longer realizes, since it is already ahead of time and receives enough acks to finish. 

This PR fixes the issue by checking the sequence number of the ack. If the ack is for a package with a sequence number lower than our current, the ack is ignored, since we already must have received a previous ack for this sequence. 
--> Only consider the first ack for a sequence number.

Tested this with 1k file uploads to a skynode, no more errors