### PR TITLE
Refactor debian changelog generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -610,15 +610,17 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         if: matrix.config.architecture != 'amd64'
       - name: Pull multibuild-env
-        run:  docker pull auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.11
+        run:  docker pull auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0
       - name: Build and package MAVSDK (Pull Request)
         if: startsWith(github.ref, 'refs/pull/')
         run: |
+          git fetch --all --tags
+          echo "TAG_VERSION=$(git describe --always --tags $(git rev-list --tags --max-count=1) | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
-            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.11 \
-            /bin/bash -c "./tools/generate_debian_changelog.sh > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
+            /bin/bash -c "./tools/generate_debian_changelog.sh --pre=${{ env.PKG_VERSION }} --version=${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
       - name: Upload libmavsdk0_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv artefact
         uses: actions/upload-artifact@v2
         if: startsWith(github.ref, 'refs/pull/')
@@ -636,11 +638,12 @@ jobs:
       - name: Build and package MAVSDK (Release)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
+          echo "TAG_VERSION=$(${GITHUB_REF} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
-            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.11 \
-            /bin/bash -c "./tools/generate_debian_changelog.sh > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
+            /bin/bash -c "./tools/generate_debian_changelog.sh --pre=$${{ env.PKG_VERSION }} --version=$${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -615,7 +615,7 @@ jobs:
         if: startsWith(github.ref, 'refs/pull/')
         run: |
           git fetch --all --tags
-          echo "TAG_VERSION=$(git describe --always --tags $(git rev-list --tags --max-count=1) | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
+          echo "TAG_VERSION=$(git tag --points-at $GITHUB_SHA | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
@@ -638,7 +638,7 @@ jobs:
       - name: Build and package MAVSDK (Release)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo "TAG_VERSION=$(${GITHUB_REF} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
+          echo "TAG_VERSION=$(0v${GITHUB_REF} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -614,8 +614,7 @@ jobs:
       - name: Build and package MAVSDK (Pull Request)
         if: startsWith(github.ref, 'refs/pull/')
         run: |
-          git fetch --all --tags
-          echo "TAG_VERSION=$(git tag --points-at $GITHUB_SHA | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
+          echo "TAG_VERSION=$(0v${GITHUB_SHA} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
@@ -638,7 +637,8 @@ jobs:
       - name: Build and package MAVSDK (Release)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo "TAG_VERSION=$(0v${GITHUB_REF} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
+          git fetch --all --tags
+          echo "TAG_VERSION=$(git tag --points-at ${GITHUB_SHA} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -610,17 +610,15 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         if: matrix.config.architecture != 'amd64'
       - name: Pull multibuild-env
-        run:  docker pull auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0
+        run:  docker pull auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.11
       - name: Build and package MAVSDK (Pull Request)
         if: startsWith(github.ref, 'refs/pull/')
         run: |
-          git fetch --all --tags
-          echo "TAG_VERSION=$(git describe --always --tags $(git rev-list --tags --max-count=1) | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
-            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
-            /bin/bash -c "./tools/generate_debian_changelog.sh --pre=${{ env.PKG_VERSION }} --version=${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.11 \
+            /bin/bash -c "./tools/generate_debian_changelog.sh > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
       - name: Upload libmavsdk0_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv artefact
         uses: actions/upload-artifact@v2
         if: startsWith(github.ref, 'refs/pull/')
@@ -638,12 +636,11 @@ jobs:
       - name: Build and package MAVSDK (Release)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo "TAG_VERSION=$(${GITHUB_REF} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
-            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
-            /bin/bash -c "./tools/generate_debian_changelog.sh --pre=$${{ env.PKG_VERSION }} --version=$${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+            auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.11 \
+            /bin/bash -c "./tools/generate_debian_changelog.sh > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -614,7 +614,7 @@ jobs:
       - name: Build and package MAVSDK (Pull Request)
         if: startsWith(github.ref, 'refs/pull/')
         run: |
-          echo "TAG_VERSION=$(0v${GITHUB_SHA} | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" >> $GITHUB_ENV
+          echo "TAG_VERSION=0v$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           docker run -t \
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -620,7 +620,7 @@ jobs:
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
             auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
-            /bin/bash -c "./tools/generate_debian_changelog.sh ${{ env.PKG_VERSION }} ${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+            /bin/bash -c "./tools/generate_debian_changelog.sh --pre=${{ env.PKG_VERSION }} --version=${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
       - name: Upload libmavsdk0_${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv artefact
         uses: actions/upload-artifact@v2
         if: startsWith(github.ref, 'refs/pull/')
@@ -643,7 +643,7 @@ jobs:
             -v $(pwd):/buildroot \
             --workdir "/buildroot" \
             auterion/multi-buildenv:${{ matrix.config.architecture }}-v1.1.0 \
-            /bin/bash -c "./tools/generate_debian_changelog.sh ${{ env.PKG_VERSION }} ${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
+            /bin/bash -c "./tools/generate_debian_changelog.sh --pre=$${{ env.PKG_VERSION }} --version=$${{ env.TAG_VERSION }} > debian/changelog; dpkg-buildpackage -us -uc -nc -b --host-arch ${{ matrix.config.architecture }}; mkdir -p output/skynode; cd ..; for i in libmavsdk*.deb; do mv "\$i" "buildroot/output/skynode/\${i/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}/${{ env.TAG_VERSION }}-${{ env.PKG_VERSION }}_multi-buildenv}"; done"
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v1-release

--- a/tools/generate_debian_changelog.sh
+++ b/tools/generate_debian_changelog.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Date according to RFC 5322
 DATE=$(date -R)
 AUTHOR="Auterion CI"
@@ -40,7 +42,6 @@ function usage_and_exit() {
     usage
     exit $1
 }
-
 
 for i in "$@"
 do

--- a/tools/generate_debian_changelog.sh
+++ b/tools/generate_debian_changelog.sh
@@ -1,26 +1,70 @@
 #!/usr/bin/env bash
 
-# We want to extract "1.2.3" from "v1.2.3-5-g123abc".
-default_tag_version=`git describe --always --tags $(git rev-list --tags --max-count=1) | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'`
-
-# Default to 1 for package version
-if [ -z "$1" ]; then
-    package_version=1
-else
-    package_version=$1
-fi
-
-if [ -z "$2" ]; then
-    tag_version=$default_tag_version
-else
-    tag_version=$2
-fi
-
 # Date according to RFC 5322
-date=`date -R`
+DATE=$(date -R)
+AUTHOR="Auterion CI"
+EMAIL="auterionci@auterion.com"
+PRE_RELEASE=1
 
-echo "mavsdk ($tag_version-$package_version) unstable; urgency=medium"
+# Fetch tags from upstream in case they're not synced
+git fetch --tags
+
+# Get the tag which points to the current commit hash; if the current commit is not tagged, the version core defaults to the current hash
+CURRENT_REF="$(git rev-parse --short HEAD)"
+CURRENT_TAG=$(git tag --points-at "$CURRENT_REF" | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+if [ ! -z "$CURRENT_TAG" ]; then
+    VERSION=$CURRENT_TAG
+else
+    # dpkg-buildpacakge expects the version to start with a digit, hence the 0
+    VERSION="0v$CURRENT_REF"
+fi
+
+function usage() {
+cat << EOF
+    Usage:
+    $0 <options ...>
+        --version <version core; default=0v[CURRENT_REF] or [CURRENT_TAG]>
+        --pre <pre-release number; default=1>
+        --author <author name; default=Auterion CI>
+        --email <author email; default=auterionci@auterion.com>
+    Examples:
+        ./generate_debian_changelog.sh
+            --version=1.0.0
+            --pre=1
+            --author="Andreea L."
+            --email="andreea@auterion.com"
+EOF
+}
+
+function usage_and_exit() {
+    usage
+    exit $1
+}
+
+
+for i in "$@"
+do
+    case $i in
+        --version=*)
+        VERSION="${i#*=}"
+        ;;
+        --pre=*)
+        PRE_RELEASE="${i#*=}"
+        ;;
+        --author=*)
+        AUTHOR="${i#*=}"
+        ;;
+        --email=*)
+        EMAIL="${i#*=}"
+        ;;
+        *) # unknown option
+        usage_and_exit 1
+        ;;
+    esac
+done
+
+echo "mavsdk ($VERSION-$PRE_RELEASE) unstable; urgency=medium"
 echo ""
-echo "  * Initial release"
+echo "  * Auterion MAVSDK release"
 echo ""
-echo " -- Helge Bahmann <helge@auterion.com>  $date"
+echo " -- $AUTHOR $EMAIL $DATE"


### PR DESCRIPTION
This PR reworks the `generate_debian_changelog.sh` script a bit. Namely it:
* Adds args for author and email, so we stop tagging every mavsdk dev with Helge's name; when not provided, by default the author is the Auterion CI
* Replaces the previous `git describe` used for the default tag version with either the current commit hash (+ "0v" prepended) or the tag which points to the commit hash. This is the main driver behind the refactor. In the previous implementation  `dpkg-buildpacakge` would fail in CI when tags weren't fully synced, because then the version defaults to the hash and the hash isn't guranteed to start with a digit, which is a dpkg requirement. This meant you basically couldn't reliably issue a build on a non-tagged mavsdk commit.

