### PR TITLE
tools: Remove internal tag fetching

### DIFF
--- a/tools/generate_debian_changelog.sh
+++ b/tools/generate_debian_changelog.sh
@@ -8,9 +8,6 @@ AUTHOR="Auterion CI"
 EMAIL="auterionci@auterion.com"
 PRE_RELEASE=1
 
-# Fetch tags from upstream in case they're not synced
-git fetch --tags
-
 # Get the tag which points to the current commit hash; if the current commit is not tagged, the version core defaults to the current hash
 CURRENT_REF="$(git rev-parse --short HEAD)"
 CURRENT_TAG=$(git tag --points-at "$CURRENT_REF" | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')


### PR DESCRIPTION
The fetch line caused a bug when called from build containers that do not have the credentials configured to access the repo. It's perhaps better to sync tags externally in environments where we know that access is possible.

Note: In upstream mavsdk this should not be an issue, as it is a public repository and fetching should always work